### PR TITLE
Implemented action serialization, when operating on same computes (OMS-223)

### DIFF
--- a/opennode/knot/backend/compute.py
+++ b/opennode/knot/backend/compute.py
@@ -106,7 +106,7 @@ class ComputeAction(Action):
     def execute(self, cmd, args):
         if self.locked():
             self._lock_registry[self.context].addBoth(lambda r: self.execute(cmd, args))
-            return
+            return self._lock_registry[self.context]
         self.lock()
         d = self._execute(cmd, args)
         self.unlock(d)

--- a/opennode/knot/backend/compute.py
+++ b/opennode/knot/backend/compute.py
@@ -27,9 +27,9 @@ from opennode.knot.backend.operation import (IGetVirtualizationContainers,
                                              IUpdateVM,
                                              IMigrateVM,
                                              OperationRemoteError)
-from opennode.knot.model.compute import IManageable
 from opennode.knot.model.compute import ICompute, Compute, IVirtualCompute
 from opennode.knot.model.compute import IUndeployed, IDeployed, IDeploying
+from opennode.knot.model.compute import IManageable
 from opennode.knot.model.console import TtyConsole, SshConsole, OpenVzConsole, VncConsole
 from opennode.knot.model.network import NetworkInterface, NetworkRoute
 from opennode.knot.model.template import Template
@@ -62,7 +62,7 @@ def register_machine(host, mgt_stack=None):
         machines = db.get_root()['oms_root']['machines']
         machine = follow_symlinks(machines['by-name'][host])
         if not mgt_stack.providedBy(machine):
-            return None
+            return
         return machine
 
     @db.transact
@@ -82,16 +82,70 @@ def find_compute_v12n_container(compute, backend):
             return v12nc
 
 
-class AllocateAction(Action):
-    context(IUndeployed)
-    action('allocate')
+class ComputeAction(Action):
+    context(ICompute)
+    baseclass()
+
+    _lock_registry = {}
 
     @db.ro_transact(proxy=False)
     def subject(self, *args, **kwargs):
         return tuple((self.context.__parent__.__parent__,))
 
-    @defer.inlineCallbacks
+    def locked(self):
+        return self.context in self._lock_registry
+
+    def lock(self):
+        """ with-statement support method """
+        self._lock_registry[self.context] = defer.Deferred()
+
+    def unlock(self, d):
+        """ with-statement support method """
+        d.chainDeferred(self._lock_registry[self.context])
+
     def execute(self, cmd, args):
+        if self.locked():
+            self._lock_registry[self.context].addBoth(lambda r: self.execute(cmd, args))
+            return
+        self.lock()
+        d = self._execute(cmd, args)
+        self.unlock(d)
+        return d
+
+    def _execute(self, cmd, args):
+        """ Must be overloaded by child classes """
+        raise NotImplementedError()
+
+
+class VComputeAction(ComputeAction):
+    """Common code for virtual compute actions."""
+    context(IVirtualCompute)
+    baseclass()
+
+    @defer.inlineCallbacks
+    def _execute(self, cmd, args):
+        action_name = getattr(self, 'action_name', self._name + "ing")
+
+        name = yield db.get(self.context, '__name__')
+        parent = yield db.get(self.context, '__parent__')
+
+        cmd.write("%s %s\n" % (action_name, name))
+        submitter = IVirtualizationContainerSubmitter(parent)
+
+        try:
+            yield submitter.submit(self.job, name)
+        except Exception as e:
+            cmd.write("%s\n" % format_error(e))
+
+
+
+class AllocateAction(ComputeAction):
+    context(IUndeployed)
+    action('allocate')
+
+    @defer.inlineCallbacks
+    def _execute(self, cmd, args):
+
         @db.ro_transact
         def get_matching_machines(container):
             all_machines = db.get_root()['oms_root']['machines']
@@ -135,17 +189,21 @@ class AllocateAction(Action):
         yield DeployAction(self.context).execute(DetachedProtocol(), bestvmscontainer)
 
 
-class DeployAction(Action):
+class DeployAction(VComputeAction):
     context(IUndeployed)
 
     action('deploy')
 
-    @db.ro_transact(proxy=False)
-    def subject(self, *args, **kwargs):
-        return tuple((self.context.__parent__.__parent__,))
-
     @defer.inlineCallbacks
     def execute(self, cmd, args):
+        try:
+            self.context.lock()
+            yield self._execute(cmd, args)
+        finally:
+            self.context.unlock()
+
+    @defer.inlineCallbacks
+    def _execute(self, cmd, args):
         template = yield db.get(self.context, 'template')
 
         if not template:
@@ -193,17 +251,14 @@ class DeployAction(Action):
                 noLongerProvides(self.context, IDeploying)
             yield cleanup_deploying()
 
-class UndeployAction(Action):
+
+class UndeployAction(VComputeAction):
     context(IDeployed)
 
     action('undeploy')
 
-    @db.ro_transact(proxy=False)
-    def subject(self, *args, **kwargs):
-        return tuple((self.context.__parent__.__parent__,))
-
     @defer.inlineCallbacks
-    def execute(self, cmd, args):
+    def _execute(self, cmd, args):
         name = yield db.get(self.context, '__name__')
         parent = yield db.get(self.context, '__parent__')
 
@@ -220,7 +275,7 @@ class UndeployAction(Action):
         yield finalize_vm()
 
 
-class MigrateAction(Action):
+class MigrateAction(VComputeAction):
     context(IVirtualCompute)
 
     action('migrate')
@@ -232,10 +287,6 @@ class MigrateAction(Action):
                             help="Force offline migration, shutdown VM before migrating")
         return parser
 
-    @db.ro_transact(proxy=False)
-    def subject(self, *args, **kwargs):
-        return tuple((self.context.__parent__.__parent__,))
-
     @defer.inlineCallbacks
     def _check_vm(self, destination_vms):
         dest_submitter = IVirtualizationContainerSubmitter(destination_vms)
@@ -243,7 +294,7 @@ class MigrateAction(Action):
         defer.returnValue((yield db.get(self.context, '__name__')) in map(lambda x: x['uuid'], vmlist))
 
     @defer.inlineCallbacks
-    def execute(self, cmd, args):
+    def _execute(self, cmd, args):
 
         @db.ro_transact
         def get_destination():
@@ -310,7 +361,7 @@ class MigrateAction(Action):
             yield mv()
 
 
-class InfoAction(Action):
+class InfoAction(VComputeAction):
     """This is a temporary command used to fetch realtime info"""
     context(IVirtualCompute)
 
@@ -321,7 +372,7 @@ class InfoAction(Action):
         return tuple((self.context.__parent__,))
 
     @defer.inlineCallbacks
-    def execute(self, cmd, args):
+    def _execute(self, cmd, args):
         name = yield db.get(self.context, '__name__')
         parent = yield db.get(self.context, '__parent__')
 
@@ -337,73 +388,46 @@ class InfoAction(Action):
             cmd.write("%s\n" % format_error(e))
 
 
-class ComputeAction(Action):
-    """Common code for virtual compute actions."""
-    context(IVirtualCompute)
-    baseclass()
-
-    @db.ro_transact(proxy=False)
-    def subject(self, *args, **kwargs):
-        return tuple((self.context.__parent__.__parent__,))
-
-    @defer.inlineCallbacks
-    def execute(self, cmd, args):
-        action_name = getattr(self, 'action_name', self._name + "ing")
-
-        name = yield db.get(self.context, '__name__')
-        parent = yield db.get(self.context, '__parent__')
-
-        cmd.write("%s %s\n" % (action_name, name))
-        submitter = IVirtualizationContainerSubmitter(parent)
-
-        try:
-            yield submitter.submit(self.job, name)
-        except Exception as e:
-            cmd.write("%s\n" % format_error(e))
-
-
-class StartComputeAction(ComputeAction):
+class StartComputeAction(VComputeAction):
     action('start')
 
     job = IStartVM
 
 
-class ShutdownComputeAction(ComputeAction):
+class ShutdownComputeAction(VComputeAction):
     action('shutdown')
 
     action_name = "shutting down"
     job = IShutdownVM
 
 
-class DestroyComputeAction(ComputeAction):
+class DestroyComputeAction(VComputeAction):
     action('destroy')
 
     job = IDestroyVM
 
 
-class SuspendComputeAction(ComputeAction):
+class SuspendComputeAction(VComputeAction):
     action('suspend')
 
     job = ISuspendVM
 
 
-class ResumeAction(ComputeAction):
+class ResumeAction(VComputeAction):
     action('resume')
 
     action_name = 'resuming'
     job = IResumeVM
 
 
-class RebootAction(ComputeAction):
+class RebootAction(VComputeAction):
     action('reboot')
 
     job = IRebootVM
 
 
-class SyncAction(Action):
+class SyncAction(ComputeAction):
     """Force compute sync"""
-    context(ICompute)
-
     action('sync')
 
     @db.ro_transact(proxy=False)
@@ -411,7 +435,7 @@ class SyncAction(Action):
         return tuple((self.context,))
 
     @defer.inlineCallbacks
-    def execute(self, cmd, args):
+    def _execute(self, cmd, args):
         default = yield self.default_console()
 
         yield self.sync_consoles()

--- a/opennode/knot/backend/pingcheck.py
+++ b/opennode/knot/backend/pingcheck.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+from grokcore.component.directive import context
+from twisted.internet import defer
+from twisted.python import log
+from zope.component import provideSubscriptionAdapter
+from zope.interface import implements
+
+from opennode.knot.model.compute import ICompute
+from opennode.knot.utils.icmp import ping
+from opennode.oms.config import get_config
+from opennode.oms.endpoint.ssh.detached import DetachedProtocol
+from opennode.oms.model.model.actions import Action, action
+from opennode.oms.model.model.proc import IProcess, Proc, DaemonProcess
+from opennode.oms.model.model.symlink import follow_symlinks
+from opennode.oms.util import subscription_factory, async_sleep
+from opennode.oms.zodb import db
+
+
+class PingCheckAction(Action):
+    """Check if a Compute responds to ICMP request from OMS."""
+    context(ICompute)
+
+    action('ping-check')
+
+    def __init__(self, *args, **kwargs):
+        super(PingCheckAction, self).__init__(*args, **kwargs)
+        config = get_config()
+        self.mem_limit = config.getint('pingcheck', 'mem_limit')
+
+    @db.ro_transact(proxy=False)
+    def subject(self, args):
+        return tuple((self.context, ))
+
+    @defer.inlineCallbacks
+    def execute(self, cmd, args):
+        yield self._execute(cmd, args)
+
+    @db.transact
+    def _execute(self, cmd, args):
+        address = self.context.hostname.encode('utf-8')
+        res = ping(address)
+        self.context.last_ping = (res == 1)
+        self.context.pingcheck.append({'timestamp': datetime.utcnow(),
+                                       'result': res})
+        history_len = len(self.context.pingcheck)
+        if history_len > self.mem_limit:
+            del self.context.pingcheck[:-self.mem_limit]
+
+        ping_results = map(lambda i: i['result'] == 1, self.context.pingcheck[:3])
+
+        self.context.suspicious = not all(ping_results)
+        self.context.failure = not any(ping_results)
+
+
+class PingCheckDaemonProcess(DaemonProcess):
+    implements(IProcess)
+
+    __name__ = "ping-check"
+
+    def __init__(self):
+        super(PingCheckDaemonProcess, self).__init__()
+
+        config = get_config()
+        self.interval = config.getint('pingcheck', 'interval')
+
+    @defer.inlineCallbacks
+    def run(self):
+        while True:
+            try:
+                if not self.paused:
+                    yield self.ping_check()
+            except Exception:
+                if get_config().getboolean('debug', 'print_exceptions'):
+                    log.err(system='ping-check')
+
+            yield async_sleep(self.interval)
+
+    @defer.inlineCallbacks
+    def ping_check(self):
+
+        @db.ro_transact
+        def get_computes():
+            oms_root = db.get_root()['oms_root']
+            res = [(i, i.hostname)
+                   for i in map(follow_symlinks, oms_root['computes'].listcontent())
+                   if ICompute.providedBy(i)]
+
+            return res
+
+        ping_actions = []
+        for i, hostname in (yield get_computes()):
+            action = PingCheckAction(i)
+            d = action.execute(DetachedProtocol(), object())
+            ping_actions.append((hostname, d))
+
+        def handle_errors(e, c):
+            e.trap(Exception)
+            log.msg("Got exception when pinging compute '%s': %s" % (c, e), system='ping-check')
+            if get_config().getboolean('debug', 'print_exceptions'):
+                log.err(system='ping-check')
+
+        for c, deferred in ping_actions:
+            deferred.addErrback(handle_errors, c)
+
+provideSubscriptionAdapter(subscription_factory(PingCheckDaemonProcess), adapts=(Proc,))
+
+

--- a/opennode/knot/backend/sync.py
+++ b/opennode/knot/backend/sync.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from grokcore.component.directive import context
 from logging import ERROR
 from twisted.internet import defer
 from twisted.python import log
@@ -10,103 +8,12 @@ from opennode.knot.backend.compute import SyncAction
 from opennode.knot.backend.operation import OperationRemoteError
 from opennode.knot.model.backend import IKeyManager
 from opennode.knot.model.compute import ICompute, IManageable
-from opennode.knot.utils.icmp import ping
 from opennode.oms.config import get_config
 from opennode.oms.endpoint.ssh.detached import DetachedProtocol
-from opennode.oms.model.model.actions import Action, action
 from opennode.oms.model.model.proc import IProcess, Proc, DaemonProcess
 from opennode.oms.model.model.symlink import follow_symlinks
 from opennode.oms.util import subscription_factory, async_sleep
 from opennode.oms.zodb import db
-
-
-class PingCheckAction(Action):
-    """Check if a Compute responds to ICMP request from OMS."""
-    context(ICompute)
-
-    action('ping-check')
-
-    def __init__(self, *args, **kwargs):
-        super(PingCheckAction, self).__init__(*args, **kwargs)
-        config = get_config()
-        self.mem_limit = config.getint('pingcheck', 'mem_limit')
-
-    @db.ro_transact(proxy=False)
-    def subject(self, args):
-        return tuple((self.context, ))
-
-    @defer.inlineCallbacks
-    def execute(self, cmd, args):
-        yield self._execute(cmd, args)
-
-    @db.transact
-    def _execute(self, cmd, args):
-        address = self.context.hostname.encode('utf-8')
-        res = ping(address)
-        self.context.last_ping = (res == 1)
-        self.context.pingcheck.append({'timestamp': datetime.utcnow(),
-                                       'result': res})
-        history_len = len(self.context.pingcheck)
-        if history_len > self.mem_limit:
-            del self.context.pingcheck[:-self.mem_limit]
-
-        ping_results = map(lambda i: i['result'] == 1, self.context.pingcheck[:3])
-
-        self.context.suspicious = not all(ping_results)
-        self.context.failure = not any(ping_results)
-
-
-class PingCheckDaemonProcess(DaemonProcess):
-    implements(IProcess)
-
-    __name__ = "ping-check"
-
-    def __init__(self):
-        super(PingCheckDaemonProcess, self).__init__()
-
-        config = get_config()
-        self.interval = config.getint('pingcheck', 'interval')
-
-    @defer.inlineCallbacks
-    def run(self):
-        while True:
-            try:
-                if not self.paused:
-                    yield self.ping_check()
-            except Exception:
-                if get_config().getboolean('debug', 'print_exceptions'):
-                    log.err(system='ping-check')
-
-            yield async_sleep(self.interval)
-
-    @defer.inlineCallbacks
-    def ping_check(self):
-
-        @db.ro_transact
-        def get_computes():
-            oms_root = db.get_root()['oms_root']
-            res = [(i, i.hostname)
-                   for i in map(follow_symlinks, oms_root['computes'].listcontent())
-                   if ICompute.providedBy(i)]
-
-            return res
-
-        ping_actions = []
-        for i, hostname in (yield get_computes()):
-            action = PingCheckAction(i)
-            d = action.execute(DetachedProtocol(), object())
-            ping_actions.append((hostname, d))
-
-        def handle_errors(e, c):
-            e.trap(Exception)
-            log.msg("Got exception when pinging compute '%s': %s" % (c, e), system='ping-check')
-            if get_config().getboolean('debug', 'print_exceptions'):
-                log.err(system='ping-check')
-
-        for c, deferred in ping_actions:
-            deferred.addErrback(handle_errors, c)
-
-provideSubscriptionAdapter(subscription_factory(PingCheckDaemonProcess), adapts=(Proc,))
 
 
 @db.ro_transact
@@ -215,9 +122,9 @@ class SyncDaemonProcess(DaemonProcess):
         sync_actions = []
         for i, hostname in (yield get_manageable_machines()):
             if hostname not in self.outstanding_requests:
-                action = SyncAction(i)
+                syncaction = SyncAction(i)
                 log.msg("Syncing started: '%s'" % hostname, system='sync')
-                deferred = action.execute(DetachedProtocol(), object())
+                deferred = syncaction.execute(DetachedProtocol(), object())
                 self.outstanding_requests[hostname] = deferred
                 sync_actions.append((hostname, deferred))
             else:


### PR DESCRIPTION
I decided to implement it differently, than we initially devised. Instead of a marker interface, I've implemented a class-wide lock registry with Twisted deferred-aided action chaining/serialization. This allowed me to generalize the implementation over all of the Compute-specific actions (which I realized by extracting a base class called ComputeAction and renaming old ComputeAction into VComputeAction to better reflect its true purpose and context). 

Still, there are significant gaps in this implementation, as commands and Compute-specific event handlers are not included into this scheme. This needs additional work.

As commands are usually generic and don't know anything about Computes (they are implemented in OMS, not KNOT), it is also possible we don't really need them to lock Computes at all. One notable exception though is `mv`, which definitely needs locking implemented.
