### PR TITLE
Fix VirtualCompute URLs to be based on /computes and not become empty due to restrictive permissions

### DIFF
--- a/opennode/knot/model/compute.py
+++ b/opennode/knot/model/compute.py
@@ -411,8 +411,6 @@ class VirtualComputeLocation(Adapter):
     context(IVirtualCompute)
 
     def get_url(self):
-        if not self.context.__parent__:
-            return
         return '/computes/%s/' % (self.context.__name__)
 
 

--- a/opennode/knot/model/compute.py
+++ b/opennode/knot/model/compute.py
@@ -1,16 +1,19 @@
 from __future__ import absolute_import
 
 from grokcore.component import context
+from grokcore.component import Adapter, implements
 import netaddr
 from zope import schema
 from zope.component import provideSubscriptionAdapter, provideAdapter
-from zope.interface import Interface, implements
+from zope.interface import Interface
+
 
 from opennode.knot.model.console import Consoles
 from opennode.knot.model.network import NetworkInterfaces, NetworkRoutes
 from opennode.knot.model.template import Templates
 from opennode.knot.model.zabbix import IZabbixConfiguration
 from opennode.oms.config import get_config
+from opennode.oms.model.location import ILocation
 from opennode.oms.model.form import alsoProvides
 from opennode.oms.model.model.actions import ActionsContainerExtension
 from opennode.oms.model.model.base import Container
@@ -20,6 +23,7 @@ from opennode.oms.model.model.stream import MetricsContainerExtension, IMetrics
 from opennode.oms.model.schema import Path
 from opennode.oms.security.directives import permissions
 from opennode.oms.util import adapter_value
+from opennode.oms.zodb import db
 
 M = 10 ** 6
 
@@ -400,6 +404,16 @@ class ComputeTags(ModelTags):
                     # graceful ignoring of incorrect ips
                     pass
         return res
+
+
+class VirtualComputeLocation(Adapter):
+    implements(ILocation)
+    context(IVirtualCompute)
+
+    def get_url(self):
+        if not self.context.__parent__:
+            return
+        return '/computes/%s/' % (self.context.__name__)
 
 
 provideAdapter(adapter_value(['cpu_usage', 'memory_usage', 'network_usage', 'diskspace_usage']),


### PR DESCRIPTION
OMS-500
